### PR TITLE
Cloudposse module version updated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,11 @@ terraform {
 
 
 module "budgets" {
-  source  = "cloudposse/budgets/aws"
-  version = "0.4.0"
+  # source  = "cloudposse/budgets/aws"
+  # version = "0.4.1"
+  # WE NEED UNCOMMENT ONCE THE ISSUE https://github.com/cloudposse/terraform-aws-budgets/issues/40 IS CLOSED
+  source = "github.com/cloudposse/terraform-aws-budgets?ref=0.4.1"
+
 
   budgets = var.budgets
 


### PR DESCRIPTION
Why:
* We need to point to the latest version module from 0.4.0 to 0.4.1 
How:
* Updated the main.tf value and source with git-based URL due to an issue with Cloudcoposee changes.

issue: https://github.com/sourcefuse/terraform-aws-arc-billing/issues/11

## Description
Due to an issue with Cloudcoposee changes, we need to update the main.tf value and source with a git-based URL to point to the latest version module from 0.4.0 to 0.4.1.

 
## Related Issue

- [11](https://github.com/sourcefuse/terraform-aws-arc-billing/issues/11): Pointing to the latest cloudpose version module from 0.4.0 to 0.4.1 

## Checklist

Please ensure that the following steps are completed before submitting the pull request:

- [x] Code follows the Terraform best practices and style guidelines.
- [x] Changes are appropriately documented, including any necessary updates to README or other documentation files.
- [x] Unit tests have been added or updated to cover the changes introduced by this pull request.
- [x] Changes have been tested locally and verified to work as expected.
- [x] The code has been reviewed to align with the project's goals and standards.
- [x] Dependencies and backward compatibility have been considered and addressed if applicable.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions

Run terrfaorm init and terraform plan

## ScreenShots
![Apply_01](https://github.com/sourcefuse/terraform-aws-arc-billing/assets/95069214/74491f33-14e4-4f7a-bedd-6e8ab892ba8d)
![Apply_02](https://github.com/sourcefuse/terraform-aws-arc-billing/assets/95069214/c6c3fc04-c765-422e-be63-0aeef91ae723)
![Apply_03](https://github.com/sourcefuse/terraform-aws-arc-billing/assets/95069214/70d07545-4989-472c-a46d-ae3ba50e8e7e)
![AWS budget](https://github.com/sourcefuse/terraform-aws-arc-billing/assets/95069214/91d14cc8-6ceb-47e0-ab0c-aa36e9ef910a)
